### PR TITLE
Change submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/--force"]
 	path = vendor/--force
-	url = git@github.com:PtiLuky/libdummy.git
+	url = git@github.com:dummymeuporg/libdummy.git
 [submodule "vendor/libdummy"]
 	path = vendor/libdummy
-	url = git@github.com:PtiLuky/libdummy.git
+	url = git@github.com:dummymeuporg/libdummy.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ before_install:
         - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         - sudo apt-get update -qq
 
-        
-# Here we fetch pre-built binaries of dependencies        
+
+# Here we fetch pre-built binaries of dependencies
 install:
   # C++17
   - sudo apt-get install -qq g++-8
@@ -63,11 +63,10 @@ install:
   - sudo wget -O lua-5.3.5_Linux313_64_lib.tar.gz https://sourceforge.net/projects/luabinaries/files/5.3.5/Linux%20Libraries/lua-5.3.5_Linux313_64_lib.tar.gz/download
   - tar -C lua -zxf lua-5.3.5_Linux313_64_lib.tar.gz
   - cd ${TRAVIS_BUILD_DIR}
-  
+
 script:
         # Check versions of gcc, g++ and cmake
         - cmake -DLUA_INCLUDE_DIR=${TRAVIS_BUILD_DIR}/lua/include/ -DLUA_LIBRARIES=${TRAVIS_BUILD_DIR}/lua/liblua53.so -DLUA_LIBRARY=${TRAVIS_BUILD_DIR}/lua/liblua53.so .
         - make clean
         - build-wrapper-linux-x86-64 --out-dir bw-outputs make -j 2 dummyeditor
         - sonar-scanner
- 

--- a/src/drawingToolbarWidget.cpp
+++ b/src/drawingToolbarWidget.cpp
@@ -120,7 +120,6 @@ void DrawingToolBarWidget::visitGraphicLayer(
     DrawingTools::DrawingTool* tool;
 
     switch (m_state) {
-
     case GraphicToolsState:
         tool = mapScene()->drawingTool();
         if (nullptr != tool) {
@@ -145,7 +144,6 @@ void DrawingToolBarWidget::visitGraphicLayer(
     DrawingTools::DrawingTool* tool;
 
     switch (m_state) {
-
     case BlockingToolsState:
         // TODO: clean this
         tool = mapScene()->drawingTool();

--- a/src/editor/project.cpp
+++ b/src/editor/project.cpp
@@ -137,7 +137,6 @@ void Project::saveProjectFile()
 void Project::dumpToXmlNode(QDomDocument& doc, QDomElement& xmlNode,
                             QStandardItem* modelItem)
 {
-
     for (int i = 0; i < modelItem->rowCount(); ++i) {
         QStandardItem* mapItem = modelItem->child(i);
 

--- a/src/mainWindow.cpp
+++ b/src/mainWindow.cpp
@@ -168,7 +168,6 @@ void MainWindow::newProject()
 
 void MainWindow::openProject()
 {
-
     if (nullptr != m_currentProject) {
         closeCurrentProject();
     }


### PR DESCRIPTION
One previous commit changed url of submodule to a fork because of needed dependency.

Now the fix of submodule is done and updated we can use the correct submodule instead of the fork.